### PR TITLE
Updated ChainCore.php to add confidence checks

### DIFF
--- a/src/ChainCore.php
+++ b/src/ChainCore.php
@@ -129,6 +129,22 @@ class ChainCore implements ChainInterface
     }
 
     /**
+     * @param $hash
+     * @return mixed
+     * @throws ChainException
+     */
+    public function get_transaction_confidence($hash)
+    {
+        try {
+            $response = $this->client->get("transactions/{$hash}/confidence");
+        } catch (RequestException $e) {
+            throw new ChainException($e->getResponse()->getbody());
+        }
+
+        return json_decode($response->getBody());
+    }
+
+    /**
      * @param $hex
      * @return mixed
      * @throws ChainException


### PR DESCRIPTION
Chain.com lets you check the transaction hash for a confidence level. See https://chain.com/docs#bitcoin-transaction-confidence
